### PR TITLE
Fix API key authentication - add credential validation

### DIFF
--- a/src/bw_client.py
+++ b/src/bw_client.py
@@ -104,11 +104,22 @@ class BitwardenClient:
         self.bw_cmd = bw_cmd
         self.session = session
         self.server = server  # Store server URL for use in _run method
-        self.client_id = client_id
-        self.client_secret = client_secret
+        self.client_id = client_id.strip() if client_id else None
+        self.client_secret = client_secret.strip() if client_secret else None
         self.use_api_key = (
             use_api_key and client_id is not None and client_secret is not None
         )
+        
+        # Validate API key format if using API key authentication
+        if self.use_api_key and self.client_id:
+            # Vaultwarden client_id should start with "organization." or "user."
+            if not (self.client_id.startswith("organization.") or self.client_id.startswith("user.")):
+                logger.warning(
+                    f"client_id format may be incorrect. Expected format: 'organization.UUID' or 'user.UUID', "
+                    f"got prefix: '{self.client_id.split('.')[0] if '.' in self.client_id else 'NO_DOT_FOUND'}'"
+                )
+            logger.debug(f"client_id format check: starts with '{self.client_id.split('.')[0]}', length: {len(self.client_id)}")
+        
         if server:
             logger.info(f"Configuring BW server: {server}")
             # Use both bw config server AND environment variables for maximum compatibility

--- a/src/run.py
+++ b/src/run.py
@@ -18,6 +18,10 @@ def require_env(name: str) -> str:
     val = os.getenv(name)
     if not val:
         raise RuntimeError(f"Missing required environment variable: {name}")
+    # Strip whitespace and quotes that might be in the environment variable
+    val = val.strip().strip('"').strip("'")
+    if not val:
+        raise RuntimeError(f"Environment variable {name} is empty after stripping whitespace")
     return val
 
 


### PR DESCRIPTION
## Summary
Fixes "Invalid client_id" errors by adding proper credential validation and whitespace handling.

## Problem
After fixing the server configuration, authentication fails with:
```
Invalid client_id
```

This can be caused by:
- Whitespace or newlines in environment variables
- Quotes around credential values
- Incorrect credential format

## Solution
1. **Strip whitespace and quotes** from all environment variables in `require_env()`
2. **Validate client_id format** - Vaultwarden requires format: `organization.{UUID}` or `user.{UUID}`
3. **Add debug logging** to show credential format without exposing actual values
4. **Strip whitespace** from credentials in BitwardenClient initialization

## Changes Made
- `src/run.py`: Updated `require_env()` to strip whitespace and quotes
- `src/bw_client.py`: Added client_id format validation and better debug logging

## What to Check

### 1. Verify Your BW_CLIENT_ID Format
Your `BW_CLIENT_ID` should look like one of these:
```
organization.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
user.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
```

### 2. Check for Whitespace
Make sure your `.env` file or docker-compose.yml doesn't have:
```yaml
# BAD - quotes and spaces
BW_CLIENT_ID: " organization.xxxxx "

# GOOD
BW_CLIENT_ID: organization.xxxxx
```

### 3. Regenerate Credentials if Needed
If format looks wrong, regenerate in Vaultwarden:
1. Settings → Security → Keys
2. Delete old key
3. Create new API key
4. Copy values exactly (no extra spaces)

## Testing
After merging, rebuild and check logs:
```bash
docker compose build && docker compose up -d
docker compose logs -f backvault
```

Look for the debug line showing client_id format validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)