### PR TITLE
Fix cryptography module import by removing redundant pip upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,11 +117,9 @@ ENV HOME=/home/backvault
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Upgrade pip in the runtime environment to fix CVE-2025-8869
-RUN pip install --upgrade "pip>=25.3" && \
-    # Remove system pip to eliminate duplicate detection by security scanners
-    # The venv pip (25.3+) in /opt/venv/bin will be used via PATH
-    rm -rf /usr/local/lib/python3.12/site-packages/pip* || true
+# Remove system pip to eliminate duplicate CVE detection by security scanners
+# The venv pip (25.3+, upgraded in builder stage) in /opt/venv/bin is used via PATH
+RUN rm -rf /usr/local/lib/python3.12/site-packages/pip* || true
 
 # Copy Bitwarden CLI from builder
 COPY --from=builder /tmp/bw /usr/local/bin/bw


### PR DESCRIPTION
## Summary
- Fixes `ModuleNotFoundError: No module named 'cryptography'` that prevented application startup
- Removes redundant pip upgrade in runtime stage that was corrupting the virtual environment

## Problem
After the recent Docker multi-stage build changes, the application failed to start with:
```
ModuleNotFoundError: No module named 'cryptography'
```

The issue was caused by upgrading pip in the runtime stage (line 121) after copying the virtual environment from the builder stage. This corrupted the venv and broke installed packages.

## Solution
- Remove the redundant `pip install --upgrade "pip>=25.3"` command from the runtime stage
- The builder stage already upgrades pip to 25.3+ (line 53) before installing dependencies
- Keep the system pip cleanup to avoid duplicate CVE-2025-8869 detection

## Test plan
- [ ] Rebuild Docker image: `docker-compose build`
- [ ] Run container and verify application starts without cryptography import errors
- [ ] Verify pip version is still 25.3+ in the container
- [ ] Verify CVE-2025-8869 is not detected by security scanners

🤖 Generated with [Claude Code](https://claude.com/claude-code)