### PR TITLE
Fix entrypoint to use virtual environment Python

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ touch "$LOG_FILE"
 # Function to run backup
 run_backup() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - Starting backup..."
-    /usr/local/bin/python /app/run.py 2>&1 | tee -a "$LOG_FILE"
+    python /app/run.py 2>&1 | tee -a "$LOG_FILE"
     local exit_code=${PIPESTATUS[0]}
     if [ $exit_code -eq 0 ]; then
         echo "$(date '+%Y-%m-%d %H:%M:%S') - Backup completed successfully"


### PR DESCRIPTION
## Summary
- Fixes `ModuleNotFoundError: No module named 'cryptography'` by using the correct Python interpreter
- Changes entrypoint.sh to use venv Python instead of system Python

## Problem
After the Docker multi-stage build changes, the application failed to start with:
```
ModuleNotFoundError: No module named 'cryptography'
```

PR #10 addressed a redundant pip upgrade, but the root cause was actually in `entrypoint.sh`. The script was explicitly calling `/usr/local/bin/python` (system Python) instead of using the PATH which includes `/opt/venv/bin` first. This meant the application was running with system Python which doesn't have access to the packages installed in the virtual environment.

## Solution
- Change `entrypoint.sh` line 23 from `/usr/local/bin/python` to `python`
- This allows the PATH to resolve correctly to `/opt/venv/bin/python`
- The venv Python has access to all installed packages including cryptography

## Testing
Verified that:
- ✅ The cryptography module imports successfully
- ✅ The application starts and runs (progresses past imports to check environment variables)
- ✅ All venv packages are accessible at runtime

## Test plan
- [ ] Rebuild Docker image: `docker-compose build`
- [ ] Run container and verify application starts without cryptography import errors
- [ ] Confirm application progresses to normal runtime errors (missing env vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)