### PR TITLE
Use full path for bw command to fix subprocess resolution

### DIFF
--- a/src/bw_client.py
+++ b/src/bw_client.py
@@ -84,7 +84,7 @@ def retry_with_backoff(
 class BitwardenClient:
     def __init__(
         self,
-        bw_cmd: str = "bw",
+        bw_cmd: str = "/usr/local/bin/bw",
         session: str | None = None,
         server: str | None = None,
         client_id: str | None = None,
@@ -94,7 +94,7 @@ class BitwardenClient:
         """
         Initialize Bitwarden client wrapper.
 
-        :param bw_cmd: Path to bw CLI command (default "bw")
+        :param bw_cmd: Path to bw CLI command (default "/usr/local/bin/bw")
         :param session: Existing BW_SESSION token (optional)
         :param server: Bitwarden server URL (optional, Vaultwarden compatible)
         :param client_id: Client ID for API key login (optional)


### PR DESCRIPTION
## Summary
- Fixes `[Errno 2] No such file or directory: 'bw'` error
- Changes default bw_cmd from "bw" to "/usr/local/bin/bw"

## Problem  
After fixing the cryptography import issue in PR #11, the application encountered another error:
```
ERROR: Login failed: [Errno 2] No such file or directory: 'bw'
WARNING: Logout encountered an error: [Errno 2] No such file or directory: 'bw'
```

Python's `subprocess` module was unable to find the `bw` (Bitwarden CLI) binary even though `/usr/local/bin` was in the PATH. This appears to be a PATH resolution issue when subprocess runs commands.

## Solution
- Change the default `bw_cmd` parameter in `BitwardenClient.__init__()` from `"bw"` to `"/usr/local/bin/bw"`
- This provides the full path to the binary, eliminating the need for PATH resolution
- Users can still override this by passing a custom `bw_cmd` parameter if needed

## Testing
Verified that:
- ✅ The bw binary is found and can be executed
- ✅ Application progresses past bw initialization
- ✅ Only fails on missing environment variables (expected behavior)

## Test plan
- [ ] Rebuild Docker image: `docker-compose build`
- [ ] Run container and verify no "bw: No such file or directory" errors
- [ ] Confirm bw commands execute successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)