### PR TITLE
Simplify to Linux x86_64 only and fix bw binary path

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -84,7 +79,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,146 +1,41 @@
 # Building BackVault Docker Images
 
-This guide explains how to build BackVault Docker images correctly for different platforms.
+This guide explains how to build BackVault Docker images for Linux x86_64.
 
-## TL;DR - Quick Commands
+## Platform Support
 
-### **Building on macOS (Intel or Apple Silicon)**
+BackVault is designed for **Linux x86_64 (amd64) only**. This simplifies deployment and ensures compatibility with most server environments.
 
-**For deployment on Linux servers (most common):**
-```bash
-docker build --platform linux/amd64 -t backvault:latest .
-```
+## Quick Commands
 
-**For ARM servers (Raspberry Pi, AWS Graviton):**
-```bash
-docker build --platform linux/arm64 -t backvault:latest .
-```
-
-### **Building on Linux**
+### Building on Linux
 
 ```bash
-# Builds for your current architecture automatically
 docker build -t backvault:latest .
 ```
 
-### **Multi-Architecture Build (for publishing)**
+### Building on macOS
 
 ```bash
-# Set up buildx (one-time setup)
-docker buildx create --use --name multiarch
-
-# Build for multiple architectures
-docker buildx build \
-  --platform linux/amd64,linux/arm64,linux/arm/v7 \
-  -t backvault:latest \
-  --push \
-  .
-```
-
----
-
-## Understanding Platform Detection
-
-### The Problem
-
-Docker on macOS runs in a Linux VM, but the Dockerfile needs to know which **target platform** to build for, not which platform you're building **from**.
-
-**Example:**
-- You're on: `macOS arm64` (Apple Silicon M1/M2)
-- Docker container runs: `Linux`
-- You want binary for: `Linux amd64` (Intel server)
-
-### The Solution
-
-The Dockerfile uses Docker's automatic build arguments:
-
-```dockerfile
-ARG TARGETPLATFORM  # e.g., "linux/amd64"
-ARG TARGETARCH      # e.g., "amd64"
-```
-
-These tell the Dockerfile which architecture to download the Bitwarden CLI binary for.
-
----
-
-## Build Scenarios
-
-### Scenario 1: Building on Mac for Linux Server (Most Common)
-
-**Problem:** Without --platform, Docker might build for arm64 but you need amd64
-
-**Solution:**
-```bash
-# Always specify the target platform when building on Mac
+# Specify linux/amd64 platform
 docker build --platform linux/amd64 -t backvault:latest .
 ```
 
-**Why this works:**
-- Docker's TARGETARCH becomes "amd64"
-- Dockerfile downloads x86_64 Bitwarden CLI binary
-- Image works on Intel/AMD Linux servers
-
-### Scenario 2: Building on Mac for ARM Server
-
-If you're deploying to:
-- Raspberry Pi 4/5
-- AWS Graviton instances
-- Other ARM64 servers
+### Using Docker Compose
 
 ```bash
-docker build --platform linux/arm64 -t backvault:latest .
+docker-compose build
 ```
-
-### Scenario 3: Building on Linux
-
-On a Linux machine, Docker detects the architecture automatically:
-
-```bash
-# No --platform needed on Linux
-docker build -t backvault:latest .
-```
-
-### Scenario 4: Multi-Architecture Build (CI/CD)
-
-For publishing to registries with multi-arch support:
-
-```bash
-# One-time: Create buildx builder
-docker buildx create --use --name backvault-builder
-
-# Build and push to registry
-docker buildx build \
-  --platform linux/amd64,linux/arm64,linux/arm/v7 \
-  -t ghcr.io/yourusername/backvault:latest \
-  --push \
-  .
-```
-
----
-
-## Architecture Mapping
-
-The Dockerfile maps Docker's architecture names to Bitwarden CLI binaries:
-
-| Docker TARGETARCH | Bitwarden Binary | Use Case |
-|-------------------|------------------|----------|
-| `amd64` | `x86_64` | Intel/AMD servers (most common) |
-| `arm64` | `aarch64` | Apple Silicon, AWS Graviton, Pi 4/5 |
-| `arm/v7` | `armv7` | Raspberry Pi 2/3 |
 
 ---
 
 ## Verifying Your Build
 
-### Check the Target Platform
+### Check the Built Image
 
 During build, you'll see:
 ```
-Building for platform: linux/amd64
-Target architecture: amd64
-Installing Bitwarden CLI version: 2024.10.2
-Downloading for architecture: x86_64
-Downloading: https://github.com/bitwarden/clients/releases/download/cli-v2024.10.2/bw-linux-x86_64-2024.10.2.zip
+Installing Bitwarden CLI version: 2024.10.2 for Linux x86_64
 ```
 
 ### Test the Built Image
@@ -149,10 +44,7 @@ Downloading: https://github.com/bitwarden/clients/releases/download/cli-v2024.10
 # Check the binary architecture
 docker run --rm --entrypoint /bin/bash backvault:latest -c "file /usr/local/bin/bw"
 
-# Should show:
-# - "x86-64" for amd64
-# - "aarch64" for arm64
-# - "ARM" for arm/v7
+# Should show: "ELF 64-bit LSB executable, x86-64"
 ```
 
 ### Run a Quick Test
@@ -169,26 +61,29 @@ docker run --rm \
 
 ## Common Issues
 
-### Issue: "exec format error"
+### Issue: "exec format error" on macOS ARM (M1/M2/M3)
 
 **Symptom:**
 ```
-standard_init_linux.go:228: exec user process caused: exec format error
+exec user process caused: exec format error
 ```
 
-**Cause:** Binary architecture doesn't match the container's architecture
+**Cause:** You're running an x86_64 image on ARM architecture without emulation
 
-**Solution:**
-- You built for wrong platform
-- Rebuild with correct `--platform` flag
-
-**Example:**
+**Solution:** Use the `--platform` flag:
 ```bash
-# Built for arm64 but running on amd64 server
-docker build --platform linux/amd64 -t backvault:latest .
+docker run --platform linux/amd64 --rm backvault:latest
 ```
 
-### Issue: Binary works in build but fails at runtime with SIGTRAP
+Or in docker-compose.yml:
+```yaml
+services:
+  backvault:
+    platform: linux/amd64
+    # ...
+```
+
+### Issue: Binary fails at runtime with SIGTRAP
 
 **Cause:** Docker's seccomp security profile
 
@@ -198,22 +93,6 @@ security_opt:
   - seccomp=unconfined
 ```
 
-### Issue: Build fails downloading Bitwarden CLI
-
-**Symptom:**
-```
-ERROR: Unsupported architecture
-```
-
-**Cause:** Building for unsupported architecture
-
-**Supported architectures:**
-- ✅ linux/amd64
-- ✅ linux/arm64
-- ✅ linux/arm/v7
-- ❌ linux/386 (not supported by Bitwarden)
-- ❌ linux/arm/v6 (not supported by Bitwarden)
-
 ---
 
 ## Best Practices
@@ -221,8 +100,8 @@ ERROR: Unsupported architecture
 ### Local Development
 
 ```bash
-# Always specify platform when building on Mac
-docker build --platform linux/amd64 -t backvault:dev .
+# Build the image
+docker build -t backvault:dev .
 
 # Test it
 docker-compose up
@@ -239,114 +118,55 @@ services:
     # ...
 ```
 
-**Option 2: Build on CI/CD**
-- Let GitHub Actions build multi-arch images
-- Images automatically match target platform
-- No local build issues
-
-**Option 3: Build on Target Server**
+**Option 2: Build on Target Server**
 ```bash
 # Build directly on the server
 ssh user@server
 git clone https://github.com/yourusername/backvault.git
 cd backvault
-docker build -t backvault:latest .  # No --platform needed
+docker build -t backvault:latest .
 ```
 
 ---
 
-## GitHub Actions Multi-Arch Builds
+## GitHub Actions Builds
 
-The repository includes GitHub Actions that automatically build for all architectures:
-
-```yaml
-# .github/workflows/docker-publish.yml
-platforms: linux/amd64,linux/arm64,linux/arm/v7
-```
-
-**Advantages:**
-- ✅ Builds happen on Linux runners (no Mac issues)
-- ✅ Proper QEMU setup for cross-compilation
-- ✅ Published images work on all platforms
-- ✅ No need to build locally
+The repository includes GitHub Actions that automatically build Docker images for Linux x86_64:
 
 **To use:**
 1. Push to main branch
-2. Wait for build (~10-15 minutes)
+2. Wait for build (~5-10 minutes)
 3. Pull and use: `docker pull ghcr.io/yourusername/backvault:latest`
 
 ---
 
-## Advanced: Testing Multiple Architectures Locally
-
-### Using QEMU
-
-```bash
-# Set up QEMU for cross-platform builds
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-
-# Create buildx builder
-docker buildx create --name multiarch --driver docker-container --use
-
-# Build and load for specific platform
-docker buildx build \
-  --platform linux/arm64 \
-  -t backvault:arm64 \
-  --load \
-  .
-
-# Test the ARM image on your Mac
-docker run --rm --security-opt seccomp=unconfined backvault:arm64 bw --version
-```
-
----
-
-## Troubleshooting Platform Issues
-
-### Check Current Platform
-
-```bash
-# On build host
-uname -m
-# x86_64 = amd64
-# aarch64 = arm64
-# armv7l = arm/v7
-
-# Docker's perspective
-docker version --format '{{.Server.Arch}}'
-```
-
-### Check Image Platform
-
-```bash
-docker image inspect backvault:latest | grep Architecture
-```
+## Troubleshooting
 
 ### Force Rebuild Without Cache
 
 ```bash
-docker build --no-cache --platform linux/amd64 -t backvault:latest .
+docker build --no-cache -t backvault:latest .
+```
+
+### Check Image Architecture
+
+```bash
+docker image inspect backvault:latest | grep Architecture
+# Should show: "amd64"
 ```
 
 ---
 
 ## Summary
 
-**Building on macOS?**
-→ Always use `--platform linux/amd64` (or your target platform)
-
-**Building on Linux?**
-→ No --platform flag needed
-
-**Publishing multi-arch?**
-→ Use GitHub Actions (already configured)
-
-**Quick test?**
-→ `docker run --rm --entrypoint /bin/bash backvault:latest -c "file /usr/local/bin/bw"`
+- **Platform**: Linux x86_64 (amd64) only
+- **Building on Linux**: `docker build -t backvault:latest .`
+- **Building on macOS**: `docker build --platform linux/amd64 -t backvault:latest .`
+- **Production**: Use pre-built images from GitHub Container Registry
 
 ---
 
 **Need Help?**
-- Check the build logs for "Building for platform:" message
-- Verify the binary architecture matches your target
-- Use GitHub Actions for production builds (easier and more reliable)
+- Check the build logs for "Installing Bitwarden CLI version" message
+- Verify the binary architecture is x86_64
+- Use GitHub Actions for production builds (recommended)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,35 +3,14 @@
 # ============================================================================
 # This multi-stage build reduces the final image size and attack surface by
 # separating build-time dependencies from runtime dependencies.
+#
+# PLATFORM: Linux x86_64 only
 # ============================================================================
 
 # ============================================================================
 # Stage 1: Builder - Install dependencies and compile packages
 # ============================================================================
 FROM python:3.14-alpine AS builder
-
-# ============================================================================
-# Multi-Platform Build Configuration
-# ============================================================================
-# Docker automatically provides these build arguments when using --platform
-# or when building with buildx for multiple architectures.
-#
-# TARGETPLATFORM: Full platform string (e.g., "linux/amd64", "linux/arm64")
-# TARGETARCH: Architecture component (e.g., "amd64", "arm64", "arm")
-# TARGETVARIANT: Architecture variant (e.g., "v7" for arm/v7)
-#
-# These are used to download the correct Bitwarden CLI binary for the
-# target platform, not the build host platform.
-#
-# Example usage:
-#   docker build --platform linux/amd64 -t backvault:latest .
-#
-# See BUILD.md for detailed platform-specific build instructions.
-# ============================================================================
-ARG TARGETPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
-ARG TARGETVARIANT
 
 # Install build dependencies for Python packages and Bitwarden CLI download
 RUN apk add --no-cache \
@@ -53,36 +32,18 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --upgrade "pip>=25.3" && \
     pip install --no-cache-dir -r /tmp/requirements.txt
 
-# Install Bitwarden CLI with proper architecture detection
+# Install Bitwarden CLI for Linux x86_64
 RUN set -eux; \
-    echo "Building for platform: ${TARGETPLATFORM:-linux/amd64}"; \
-    echo "Target architecture: ${TARGETARCH}"; \
-    \
     # Get latest version from GitHub API
     BW_VERSION=$(curl -s https://api.github.com/repos/bitwarden/clients/releases | \
                  grep -o '"tag_name": "cli-v[^"]*"' | head -1 | \
                  sed 's/.*cli-v\([^"]*\).*/\1/') || BW_VERSION="2024.10.2"; \
     \
-    echo "Installing Bitwarden CLI version: ${BW_VERSION}"; \
+    echo "Installing Bitwarden CLI version: ${BW_VERSION} for Linux x86_64"; \
     \
-    # Map Docker architecture names to Bitwarden binary names
-    case "${TARGETARCH}" in \
-        amd64) \
-            ARCH_SUFFIX="x86_64" ;; \
-        arm64) \
-            ARCH_SUFFIX="aarch64" ;; \
-        arm) \
-            ARCH_SUFFIX="armv7" ;; \
-        *) \
-            echo "Unsupported architecture: ${TARGETARCH}"; \
-            exit 1 ;; \
-    esac; \
-    \
-    echo "Downloading for architecture: ${ARCH_SUFFIX}"; \
-    \
-    # Download the architecture-specific binary
-    curl -fsSL "https://github.com/bitwarden/clients/releases/download/cli-v${BW_VERSION}/bw-linux-${ARCH_SUFFIX}-${BW_VERSION}.zip" -o /tmp/bw.zip || \
-    curl -fsSL "https://vault.bitwarden.com/download/?app=cli&platform=linux&arch=${ARCH_SUFFIX}" -o /tmp/bw.zip; \
+    # Download the x86_64 binary
+    curl -fsSL "https://github.com/bitwarden/clients/releases/download/cli-v${BW_VERSION}/bw-linux-x86_64-${BW_VERSION}.zip" -o /tmp/bw.zip || \
+    curl -fsSL "https://vault.bitwarden.com/download/?app=cli&platform=linux" -o /tmp/bw.zip; \
     \
     unzip /tmp/bw.zip -d /tmp; \
     chmod +x /tmp/bw; \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It’s designed for hands-free, secure, and automated backups using the official
 - ✨ **Two Encryption Modes**: Choose between Bitwarden's native encrypted format or a portable, standard AES-256-GCM encrypted format
 - 🔐 **Security Hardened**: Non-root execution, log redaction, retry logic with exponential backoff
 - 🌐 Works with both Bitwarden Cloud and self-hosted Bitwarden/Vaultwarden
-- 🏗️ **Multi-Architecture Support**: Native images for amd64, arm64, and arm/v7 (Raspberry Pi)
+- 🐧 **Linux x86_64 Support**: Optimized for standard Linux servers
 - 🐳 Runs fully containerized — no setup or local dependencies required
 
 ---
@@ -25,7 +25,7 @@ You can run BackVault directly using the **published Docker image**, no build re
 
 **Available Images:**
 - GitHub Container Registry: `ghcr.io/tgrecojr/backvault:latest`
-- Multi-architecture support: amd64, arm64, arm/v7 (Raspberry Pi compatible)
+- Platform: Linux x86_64 (amd64)
 
 ```bash
 docker run -d \
@@ -313,22 +313,20 @@ docker compose up -d
 
 ---
 
-## 🔄 CI/CD and Multi-Architecture Builds
+## 🔄 CI/CD and Automated Builds
 
 BackVault uses GitHub Actions for automated building and publishing:
 
 ### Automated Workflows
 
-- **Docker Publish**: Builds and publishes multi-arch images on merge to main
+- **Docker Publish**: Builds and publishes Linux x86_64 images on merge to main
 - **Security Scan**: Weekly vulnerability scanning with Trivy and Bandit
 - **Test**: Runs linting and build tests on all PRs
 
-### Supported Architectures
+### Platform Support
 
-Images are automatically built for:
-- `linux/amd64` - Standard x86_64 systems
-- `linux/arm64` - ARM64 systems (Apple Silicon M1/M2, AWS Graviton)
-- `linux/arm/v7` - 32-bit ARM (Raspberry Pi 2+)
+Images are built for:
+- `linux/amd64` - Linux x86_64 systems
 
 ### Using Specific Versions
 
@@ -338,30 +336,19 @@ docker pull ghcr.io/tgrecojr/backvault:latest
 
 # Use specific version (when tagged)
 docker pull ghcr.io/tgrecojr/backvault:v1.0.0
-
-# Use specific architecture
-docker pull --platform linux/arm64 ghcr.io/tgrecojr/backvault:latest
 ```
 
 ### Building Locally
 
-**Important**: If building on macOS, see [BUILD.md](BUILD.md) for detailed platform-specific instructions.
-
-**On macOS (for Linux deployment):**
-```bash
-# Always specify target platform when building on Mac
-docker build --platform linux/amd64 -t backvault:local .
-```
-
 **On Linux:**
 ```bash
-# No --platform flag needed (auto-detects)
 docker build -t backvault:local .
 ```
 
-**Multi-architecture build (requires buildx):**
+**On macOS:**
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t backvault:local .
+# Specify linux/amd64 platform for deployment
+docker build --platform linux/amd64 -t backvault:local .
 ```
 
 For comprehensive build documentation including troubleshooting, see **[BUILD.md](BUILD.md)**.

--- a/src/bw_client.py
+++ b/src/bw_client.py
@@ -84,7 +84,7 @@ def retry_with_backoff(
 class BitwardenClient:
     def __init__(
         self,
-        bw_cmd: str = "bw",
+        bw_cmd: str = "/usr/local/bin/bw",
         session: str | None = None,
         server: str | None = None,
         client_id: str | None = None,
@@ -94,7 +94,7 @@ class BitwardenClient:
         """
         Initialize Bitwarden client wrapper.
 
-        :param bw_cmd: Path to bw CLI command (default "bw")
+        :param bw_cmd: Path to bw CLI command (default "/usr/local/bin/bw")
         :param session: Existing BW_SESSION token (optional)
         :param server: Bitwarden server URL (optional, Vaultwarden compatible)
         :param client_id: Client ID for API key login (optional)


### PR DESCRIPTION
## Summary
This PR simplifies BackVault to target **Linux x86_64 only**, removing multi-architecture complexity while fixing the `bw` binary path issue that was causing runtime errors.

## Problems Fixed

### 1. bw Binary Not Found Error
```
ERROR: Login failed: [Errno 2] No such file or directory: 'bw'
WARNING: Logout encountered an error: [Errno 2] No such file or directory: 'bw'
```
**Root Cause**: Python's `subprocess` couldn't find the `bw` binary even though it was in PATH.  
**Solution**: Changed default `bw_cmd` from `"bw"` to `"/usr/local/bin/bw"` for explicit path resolution.

### 2. Multi-Architecture Complexity
- Complex Dockerfile with TARGETPLATFORM/TARGETARCH logic
- QEMU setup in CI/CD
- Platform mismatch issues on macOS
- Inconsistent documentation

**Solution**: Simplified to Linux x86_64 only, which covers 99% of server deployments.

## Changes Made

### Dockerfile
- ✅ Removed all `ARG TARGETPLATFORM`, `ARG TARGETARCH`, etc.
- ✅ Removed architecture detection case statement
- ✅ Hardcoded Bitwarden CLI download to `x86_64`
- ✅ Updated comments to reflect Linux x86_64 only

### Source Code
- ✅ Changed `bw_cmd` default from `"bw"` to `"/usr/local/bin/bw"` in `BitwardenClient.__init__()`
- ✅ Updated docstring to reflect new default

### GitHub Actions
- ✅ Removed QEMU setup step
- ✅ Changed platforms from `linux/amd64,linux/arm64,linux/arm/v7` to `linux/amd64` only

### Documentation
- ✅ **BUILD.md**: Complete rewrite focusing on Linux x86_64 only
- ✅ **README.md**: Updated all references to multi-arch support
  - Changed feature from "Multi-Architecture Support" to "Linux x86_64 Support"
  - Updated platform info in Quick Start section
  - Simplified CI/CD section
  - Removed multi-arch build examples

## Testing

### Build Test
```bash
docker build --no-cache -t backvault:test .
```
✅ Build completes successfully  
✅ Bitwarden CLI downloads correctly for x86_64  
✅ All dependencies install properly

### Expected Behavior on Linux Server
After deployment, the application should:
- ✅ Find `/usr/local/bin/bw` without PATH issues
- ✅ Execute bw commands successfully
- ✅ Progress past login to normal operation

## Migration Notes

For users on:
- **Linux x86_64 servers**: No changes needed, everything works as before
- **ARM servers** (Raspberry Pi, AWS Graviton): This version will not work; would need to build ARM version manually

## Benefits

1. **Simpler codebase**: 237 fewer lines of complex multi-arch logic
2. **Faster builds**: No cross-compilation overhead
3. **Easier maintenance**: One platform to support
4. **Fewer bugs**: Eliminates platform mismatch issues
5. **Clearer docs**: Focused, straightforward instructions

## Test Plan

- [ ] Build image on Linux x86_64 server
- [ ] Verify bw binary is accessible at `/usr/local/bin/bw`
- [ ] Run container with valid credentials
- [ ] Confirm no "No such file or directory: 'bw'" errors
- [ ] Verify backup completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)