### PR TITLE
Fix bw binary path - remove hardcoded bw_cmd override in run.py

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -80,7 +80,6 @@ def main():
     # Create client
     logger.info("Connecting to vault...")
     source = BitwardenClient(
-        bw_cmd="bw",
         server=server,
         client_id=client_id,
         client_secret=client_secret,


### PR DESCRIPTION
## Summary
Fixes the persistent `[Errno 2] No such file or directory: 'bw'` error by removing the hardcoded `bw_cmd="bw"` override in `run.py`.

## Root Cause
While PR #14 changed the default `bw_cmd` value in `BitwardenClient.__init__()` from `"bw"` to `"/usr/local/bin/bw"`, the `run.py` file was **explicitly passing** `bw_cmd="bw"` when instantiating the client, which overrode the default.

```python
# Before - run.py line 82-88
source = BitwardenClient(
    bw_cmd="bw",  # ← This was overriding the default!
    server=server,
    client_id=client_id,
    client_secret=client_secret,
    use_api_key=True,
)
```

## The Fix
Removed the `bw_cmd="bw"` parameter so it uses the default value from `bw_client.py`:

```python
# After
source = BitwardenClient(
    server=server,
    client_id=client_id,
    client_secret=client_secret,
    use_api_key=True,
)
```

Now it will use the default `bw_cmd="/usr/local/bin/bw"` from the class definition.

## Why This Matters
Python's `subprocess` module couldn't find the `bw` binary when called with just `"bw"`. By using the full path `/usr/local/bin/bw`, subprocess can find and execute the binary reliably.

## Testing
After this fix is merged and the image rebuilt:
- ✅ Application should find `/usr/local/bin/bw` without errors
- ✅ No more `[Errno 2] No such file or directory: 'bw'` messages
- ✅ Bitwarden CLI commands execute successfully
- ✅ Backup operations complete normally

## Files Changed
- `src/run.py`: Removed 1 line (the `bw_cmd="bw"` parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)