### PR TITLE
fix(renovate): ignore placeholder GHCR image in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   backvault:
     # Use published image from GitHub Container Registry
     # Replace 'yourusername' with your GitHub username
+    # renovate: ignore
     image: ghcr.io/yourusername/backvault:latest
 
     # OR: Build locally (uncomment the line below and comment out 'image' above)


### PR DESCRIPTION
## Summary
- Mend dashboard was flagging this repo with `⚠️ No docker auth found - returning` as a repository problem.
- Root cause: `docker-compose.yml` references `ghcr.io/yourusername/backvault:latest` — a literal placeholder meant as documentation for downstream consumers, not a real image. Renovate's docker-compose manager was attempting to resolve it on every run, hitting the auth path on GHCR, and surfacing the warning.
- Fix: add a `# renovate: ignore` comment directly above the `image:` line so Renovate skips that entry. Real deps (e.g. `python:3.14-slim` in the Dockerfile) continue to be tracked normally.

## Test plan
- [ ] Merge and wait for next Renovate run
- [ ] Confirm the "repository problems" warning clears on the Mend dashboard
- [ ] Confirm Dockerfile digest/version PRs still flow as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)