### PR TITLE
style: apply ruff format to src/

### DIFF
--- a/src/bw_client.py
+++ b/src/bw_client.py
@@ -116,7 +116,7 @@ class BitwardenClient:
             env = os.environ.copy()
             if self.server:
                 env["BW_URL"] = self.server
-            
+
             try:
                 subprocess.run(
                     [self.bw_cmd, "config", "server", server],
@@ -130,9 +130,13 @@ class BitwardenClient:
             except subprocess.CalledProcessError as e:
                 # Some CLI versions return exit code 1 even on success
                 # Log but don't fail - environment variables will be used as fallback
-                logger.debug(f"bw config server returned code {e.returncode}, will use environment variables")
+                logger.debug(
+                    f"bw config server returned code {e.returncode}, will use environment variables"
+                )
             except Exception as e:
-                logger.warning(f"Could not run bw config server: {e}, will use environment variables")
+                logger.warning(
+                    f"Could not run bw config server: {e}, will use environment variables"
+                )
             # Note: We now set environment variables in _run() instead of using bw config server
             # This is more compatible with recent Bitwarden CLI versions and Vaultwarden
 
@@ -152,11 +156,11 @@ class BitwardenClient:
         env = os.environ.copy()
         if self.session:
             env["BW_SESSION"] = self.session
-        
+
         # Set server URL environment variable for Vaultwarden compatibility
         if self.server:
             env["BW_URL"] = self.server
-        
+
         full_cmd = [self.bw_cmd] + cmd
 
         # Log command but redact sensitive arguments
@@ -242,15 +246,19 @@ class BitwardenClient:
             env = os.environ.copy()
             env["BW_CLIENTID"] = self.client_id
             env["BW_CLIENTSECRET"] = self.client_secret
-            
+
             # Set server URL environment variables for Vaultwarden compatibility
             # Try simpler approach - just set BW_URL
             if self.server:
                 env["BW_URL"] = self.server
                 # Debug: Log that we're setting the server
                 logger.debug(f"Setting BW_URL to: {self.server}")
-                logger.debug(f"Client ID length: {len(self.client_id) if self.client_id else 0}")
-                logger.debug(f"Client Secret length: {len(self.client_secret) if self.client_secret else 0}")
+                logger.debug(
+                    f"Client ID length: {len(self.client_id) if self.client_id else 0}"
+                )
+                logger.debug(
+                    f"Client Secret length: {len(self.client_secret) if self.client_secret else 0}"
+                )
 
             cmd = [self.bw_cmd, "login", "--apikey"]
 
@@ -300,7 +308,7 @@ class BitwardenClient:
         # Only set BW_SESSION if we have a valid session (not the case after API key login)
         if self.session:
             env["BW_SESSION"] = self.session
-        
+
         # Set server URL environment variable for Vaultwarden compatibility
         if self.server:
             env["BW_URL"] = self.server

--- a/src/decrypt.py
+++ b/src/decrypt.py
@@ -18,29 +18,36 @@ ARGON2_TIME_COST = 3
 ARGON2_MEMORY_COST = 65536  # 64 MB in KiB
 ARGON2_PARALLELISM = 4
 
+
 def decrypt_data(encrypted_data: bytes, password: str) -> bytes:
     # Read version header (4 bytes)
     version_num = int.from_bytes(encrypted_data[:4], byteorder="big")
     offset = 4
 
-    salt = encrypted_data[offset:offset+SALT_SIZE]
-    nonce = encrypted_data[offset+SALT_SIZE:offset+SALT_SIZE+12]
-    ciphertext_with_tag = encrypted_data[offset+SALT_SIZE+12:]
+    salt = encrypted_data[offset : offset + SALT_SIZE]
+    nonce = encrypted_data[offset + SALT_SIZE : offset + SALT_SIZE + 12]
+    ciphertext_with_tag = encrypted_data[offset + SALT_SIZE + 12 :]
 
     # Derive key based on version
     if version_num == 1:
         # Legacy PBKDF2 format
-        print(f"Decrypting version {version_num} file (PBKDF2-HMAC-SHA256, {PBKDF2_ITERATIONS:,} iterations)", file=sys.stderr)
+        print(
+            f"Decrypting version {version_num} file (PBKDF2-HMAC-SHA256, {PBKDF2_ITERATIONS:,} iterations)",
+            file=sys.stderr,
+        )
         kdf = PBKDF2HMAC(
             algorithm=hashes.SHA256(),
             length=KEY_SIZE,
             salt=salt,
-            iterations=PBKDF2_ITERATIONS
+            iterations=PBKDF2_ITERATIONS,
         )
         key = kdf.derive(password.encode("utf-8"))
     elif version_num == 2:
         # Current Argon2id format
-        print(f"Decrypting version {version_num} file (Argon2id, {ARGON2_MEMORY_COST // 1024} MB)", file=sys.stderr)
+        print(
+            f"Decrypting version {version_num} file (Argon2id, {ARGON2_MEMORY_COST // 1024} MB)",
+            file=sys.stderr,
+        )
         key = hash_secret_raw(
             secret=password.encode("utf-8"),
             salt=salt,
@@ -57,6 +64,7 @@ def decrypt_data(encrypted_data: bytes, password: str) -> bytes:
     aesgcm = AESGCM(key)
     return aesgcm.decrypt(nonce, ciphertext_with_tag, None)
 
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(f"Usage: python {sys.argv[0]} <encrypted_file>")
@@ -68,7 +76,7 @@ if __name__ == "__main__":
     try:
         with open(file_path, "rb") as f:
             encrypted_contents = f.read()
-        
+
         decrypted_json = decrypt_data(encrypted_contents, password)
         print(decrypted_json.decode("utf-8"))
         print("\nDecryption successful.", file=sys.stderr)


### PR DESCRIPTION
## Summary
`ruff format --check src/` has been failing in the Test workflow (separate step from `ruff check`). Running `ruff format src/` cleans up trailing whitespace and a few long-line wraps in `bw_client.py` and `decrypt.py`. No behavior change — pure formatting.

Verified locally:
- `ruff check src/` → All checks passed
- `ruff format --check src/` → 3 files already formatted

## Test plan
- [ ] `Test` workflow goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)