### PR TITLE
chore(renovate): clean up overlapping packageRules and dead config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
     "before 5am every weekday",
     "every weekend"
   ],
+  "ignoreDeps": ["ghcr.io/yourusername/backvault"],
   "prConcurrentLimit": 3,
   "prCreation": "immediate",
   "rebaseWhen": "behind-base-branch",

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     ":disableRateLimiting",
     ":dependencyDashboard",
     ":semanticCommits",
-    ":enablePreCommit",
     "docker:enableMajor",
     ":timezone(America/New_York)"
   ],
@@ -21,88 +20,43 @@
   "platformAutomerge": true,
   "packageRules": [
     {
-      "matchCategories": [
-        "docker"
-      ],
+      "description": "Pin digests for all Docker images",
+      "matchDatasources": ["docker"],
       "pinDigests": true
     },
     {
-      "description": "Auto-merge non-major updates for stable images",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest"
-      ],
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "description": "Group all minor and patch updates together",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "description": "Group all minor and patch updates together with a 3-day stability window",
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "automerge": true
-    },
-    {
-      "description": "Disable auto-merge for major updates - need review",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "automerge": false,
-      "labels": [
-        "major-update"
-      ]
-    },
-    {
-      "description": "Auto-merge digest updates daily",
-      "matchUpdateTypes": [
-        "digest"
-      ],
       "automerge": true,
-      "schedule": [
-        "at any time"
-      ],
-      "minimumReleaseAge": null
-    },
-    {
-      "description": "Stability period for minor/patch before auto-merge",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Common stable images - faster auto-merge",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "postgres",
-        "mariadb",
-        "nginx",
-        "redis",
-        "traefik"
-      ],
-      "minimumReleaseAge": "1 day"
+      "description": "Disable auto-merge for major updates - need review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "labels": ["major-update"]
+    },
+    {
+      "description": "Auto-merge digest updates immediately (no stability delay)",
+      "matchUpdateTypes": ["digest"],
+      "automerge": true,
+      "schedule": ["at any time"],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Python (pip) deps follow the all-minor-patch group; called out for visibility",
+      "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ],
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": [
-      "security"
-    ]
+    "labels": ["security"]
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": [
-      "before 4am on monday"
-    ]
+    "schedule": ["before 4am on monday"]
   }
 }


### PR DESCRIPTION
## Summary
This PR does two things:

### 1. Fix the dashboard "⚠️ No docker auth found - returning" warning
The Mend debug log shows the warning is caused by Renovate trying to resolve the placeholder image `ghcr.io/yourusername/backvault:latest` in `docker-compose.yml`. The inline `# renovate: ignore` directive added in #35 is **not being honored by the docker-compose manager** — Renovate still calls `getDigest`, hits `https://ghcr.io/token?scope=repository:yourusername/backvault:pull`, gets **403 Forbidden** (the image doesn't exist), and bails with the warning.

Relevant log excerpt:
```
Dependency ghcr.io/yourusername/backvault has unsupported/unversioned value latest
getDigest(https://ghcr.io, yourusername/backvault, latest)
GET https://ghcr.io/token?... statusCode=403
Not allowed to access docker registry  (registryHost=https://ghcr.io)
No docker auth found - returning
Could not determine new digest for update.
```

The fix is to add the placeholder to `ignoreDeps` in `renovate.json`, which is enforced by the bot itself instead of per-manager comment parsing. The `python:3.14-slim` Docker Hub lookups in the same run completed cleanly with no auth issues, so this is the only source of the warning.

### 2. Clean up overlapping/dead `packageRules`
- Drop `:enablePreCommit` (no `.pre-commit-config.yaml` in the repo, so the preset was a no-op)
- Switch the `pinDigests` rule from `matchCategories: ["docker"]` to `matchDatasources: ["docker"]` to match the canonical `docker:pinDigests` form
- Remove the "Auto-merge non-major updates for stable images" rule — its `automergeType: "branch"` conflicted with the top-level `prCreation: "immediate"` and `platformAutomerge: true` (one was being silently ignored)
- Fold the standalone "Stability period" rule into the `all-minor-patch` grouping rule to avoid last-match-wins surprises
- Remove the "Common stable images" rule (postgres/mariadb/nginx/redis/traefik) — none of those images are used here, so it was dead config
- Add an explicit `pip_requirements` anchor rule for future Python-deps tunability

Validated locally with `renovate-config-validator`.

## Test plan
- [ ] Wait for next Mend Renovate run on this branch
- [ ] Confirm the "No docker auth found - returning" warning is gone from the dashboard
- [ ] Confirm grouping still produces an `all-minor-patch` PR for any pending minor/patch updates
- [ ] Confirm digest updates still auto-merge at any time
- [ ] Confirm `ghcr.io/yourusername/backvault` no longer appears in the dashboard's detected dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)