### PR TITLE
chore(renovate): switch python rule from pip_requirements to pep621

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,8 +47,8 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Python (pip) deps follow the all-minor-patch group; called out for visibility",
-      "matchManagers": ["pip_requirements"],
+      "description": "Python (pep621/uv) deps follow the all-minor-patch group; called out for visibility",
+      "matchManagers": ["pep621"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ],


### PR DESCRIPTION
## Summary
- The `pip_requirements` manager only matches `requirements*.txt` files, which were removed in the uv migration (#44).
- Switch the Python-deps `packageRule` to `matchManagers: ["pep621"]` so it applies to `pyproject.toml` / `uv.lock` updates.
- `lockFileMaintenance` already works with `uv.lock` via the `pep621` manager — no change needed there.

## Test plan
- [ ] Renovate dependency dashboard recognizes the rule on next run
- [ ] Next pep621 minor/patch update PR is grouped into `all non-major dependencies` with the 3-day stability window
- [ ] Weekly `lockFileMaintenance` PR continues to refresh `uv.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)