### PR TITLE
chore: add supply-chain gates, image signing, and SBOM attestations

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,30 +10,37 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  supply-chain:
+    name: Supply chain
+    uses: ./.github/workflows/supply-chain.yml
+    secrets: inherit
+
   build-and-push:
+    needs: supply-chain
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
       id-token: write
-    
+      attestations: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v6
@@ -42,8 +49,9 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix={{branch}}-
-      
+
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -53,3 +61,36 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign (keyless)
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,53 @@
+name: Supply chain scan
+
+on:
+  workflow_call:
+    secrets:
+      SOCKET_SECURITY_API_KEY:
+        required: true
+
+jobs:
+  scan:
+    name: Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Python
+        run: uv python install 3.14
+
+      - name: Export locked dependencies to requirements.txt
+        run: uv export --frozen --no-hashes --no-emit-project --output-file requirements-lock.txt
+
+      - name: Socket Security scan
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+        run: |
+          repo_slug="${GITHUB_REPOSITORY##*/}"
+          branch_name="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          npx -y @socketsecurity/cli@latest scan create \
+            --org grecolabs \
+            --repo "${repo_slug}" \
+            --branch "${branch_name}" \
+            --report \
+            ./
+
+      - name: OSV scan (uv.lock)
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
+        with:
+          scan-args: |-
+            --recursive
+            ./
+
+      - name: pip-audit
+        uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          inputs: requirements-lock.txt

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,9 @@
+# OSV-Scanner ignore allowlist for uv.lock at the repo root.
+# Format: https://google.github.io/osv-scanner/configuration/
+#
+# Per-vuln entries go here. Example:
+#
+# [[IgnoredVulns]]
+# id = "GHSA-xxxx-xxxx-xxxx"
+# ignoreUntil = 2026-12-31
+# reason = "Not exploitable in our usage of <package>."


### PR DESCRIPTION
## Summary
- Adds reusable `supply-chain.yml` with hard-fail gates: Socket Security scan (`grecolabs` org), OSV-Scanner recursive (uv.lock), `pip-audit` against locked deps exported via `uv export --frozen --no-hashes`.
- Wires `docker-publish.yml` build-and-push job with `needs: supply-chain` so any finding blocks the image from being pushed.
- After build: cosign keyless sign + SPDX SBOM (syft) + attest SBOM + attest build provenance, all bound to the image digest.
- Empty `osv-scanner.toml` scaffold at repo root for future per-finding allowlists.

Python pattern established in gmailclassifier — applied identically here.

## Gate order
1. `supply-chain` (Socket → OSV → pip-audit)
2. `build-and-push` runs only after supply-chain passes
3. Build → cosign sign → SBOM gen → attest SBOM → attest build provenance

## Requirements
- Repo secret `SOCKET_SECURITY_API_KEY` is already set
- `build-and-push` permissions expanded: `attestations: write` (id-token was already set)

## Test plan
- [ ] After merge to main: supply-chain runs all 3 gates, image pushed, cosign signature visible, SBOM + provenance attestations attached to digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)