### PR TITLE
fix(rbw): drop positional args from `rbw register`

### DIFF
--- a/src/bw_client.py
+++ b/src/bw_client.py
@@ -196,15 +196,12 @@ class BitwardenClient:
     ) -> str | None:
         """Register the device with the server using the personal API key.
 
-        rbw's `register` is idempotent — if already registered, it returns quickly.
-        After register, no separate `login` step is required.
+        rbw reads `email` and `base_url` from config.json (written in __init__)
+        and the API key from BW_CLIENTID / BW_CLIENTSECRET env vars. `register`
+        is idempotent — subsequent calls are no-ops once the device is enrolled.
         """
         logger.info("Registering device with vault server via API key")
-        # rbw register <email> <base_url>
-        self._run(
-            ["register", self.email, self.server],
-            include_api_key=True,
-        )
+        self._run(["register"], include_api_key=True)
         logger.info("Device registered (or already registered)")
         return None
 


### PR DESCRIPTION
## Summary

`rbw register` takes **no** positional arguments — it reads `email` and `base_url` from `config.json` (which `BitwardenClient.__init__` already writes) and the API key from `BW_CLIENTID` / `BW_CLIENTSECRET` env vars.

The merged Phase 2 code called it as `rbw register <email> <base_url>`, which trips clap with `error: unexpected argument` (exit code 2), causing the first backup attempt to fail in the retry loop on every run.

## Observed log line before fix

```
ERROR: stderr: error: unexpected argument '<email>' found
Usage: rbw register
```

## Side effect

The email and Vaultwarden URL no longer appear in the logged command (`INFO: Running command: /usr/bin/rbw register`). They were never secrets, but it's tidier this way.

## Test plan
- [ ] Pull image, restart container
- [ ] Confirm `rbw register` exits 0 on first run (device gets enrolled)
- [ ] Confirm subsequent backups also succeed (register is idempotent)
- [ ] Confirm `rbw unlock` proceeds to use the pinentry stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)