### PR TITLE
debug(rbw): set identity_url explicitly + RUST_LOG=debug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ ENV PATH="/app/.venv/bin:$PATH" \
     XDG_CONFIG_HOME=/app/.config \
     XDG_DATA_HOME=/app/.local/share \
     XDG_RUNTIME_DIR=/tmp/rbw-runtime \
-    RBW_PINENTRY=/app/pinentry.py
+    RBW_PINENTRY=/app/pinentry.py \
+    RUST_LOG=rbw=debug
 
 ENTRYPOINT ["python", "/app/entrypoint.py"]

--- a/src/bw_client.py
+++ b/src/bw_client.py
@@ -128,10 +128,14 @@ class BitwardenClient:
         """Write rbw's config.json from constructor inputs."""
         self.config_dir.mkdir(parents=True, exist_ok=True)
         config_path = self.config_dir / "config.json"
+        # Set identity_url explicitly rather than relying on rbw's auto-derivation
+        # from base_url. For self-hosted Vaultwarden the identity endpoint lives
+        # at `<base_url>/identity`.
+        base = (self.server or "").rstrip("/")
         config = {
             "email": self.email,
             "base_url": self.server,
-            "identity_url": None,
+            "identity_url": f"{base}/identity" if base else None,
             "ui_url": None,
             "notifications_url": None,
             "client_cert_path": None,
@@ -177,6 +181,10 @@ class BitwardenClient:
             logger.error(f"stderr: {e.stderr}")
             logger.error(f"Command: {' '.join(full_cmd)}")
             raise BitwardenError("rbw command failed") from e
+
+        # Surface rbw's stderr even on success so RUST_LOG=debug output is visible.
+        if result.stderr and result.stderr.strip():
+            logger.info(f"rbw stderr: {result.stderr.strip()}")
 
         output = result.stdout.strip()
         if capture_json:


### PR DESCRIPTION
## Context

After #64 fixed the `rbw register` arg issue, register still fails — but with a 400 from Vaultwarden's auth endpoint **and no corresponding entry in VW's access log**. That means the 400 is coming from upstream of VW (reverse proxy) or rbw is hitting a path that doesn't get routed to VW. Either way, rbw's URL derivation is the most likely culprit.

Observed in user's logs:
```
ERROR: stderr: rbw register: failed to log in to bitwarden instance: api request returned error: 400
```
`docker logs vaultwarden --since 2m | grep -Ei 'identity|/connect/token|400'` → no results.
`rbw --version` → 1.15.0.

## Changes

1. **Set `identity_url` explicitly** in `config.json` to `<base_url>/identity`. We were leaving it `null` and relying on rbw's auto-derivation. For self-hosted Vaultwarden this is the canonical path; pinning it removes auto-derivation as a variable. **Most likely the actual fix.**

2. **Pipe rbw stderr to our logger on success too**, not only on error. Today we discard stderr unless the subprocess returns non-zero — so any debug output never reaches the container logs.

3. **`RUST_LOG=rbw=debug`** in the runtime `ENV`. rbw uses `env_logger`; this surfaces the URLs it's hitting and what response it got.

## Expected outcomes after deploying

- **If identity_url was the issue**: `rbw register` succeeds, vault enrolls, backup runs end-to-end. Debug logs are noisy but harmless — easy to demote to `info` in a follow-up.
- **If identity_url wasn't enough**: container logs now show exactly which URL rbw POSTed to and what the server (or proxy) returned. Reverse-proxy logs (`docker logs <proxy> --since 2m`) should also light up at that point, telling us whether it's a routing or auth issue.

## Test plan
- [ ] Pull image, restart container
- [ ] If register succeeds → verify unlock/sync/export complete end-to-end
- [ ] If register still 400s → capture the new debug output (URL, request details) and share

🤖 Generated with [Claude Code](https://claude.com/claude-code)