### PR TITLE
fix(pinentry): dispatch on SETPROMPT, return correct credential

### DIFF
--- a/pinentry.py
+++ b/pinentry.py
@@ -1,33 +1,73 @@
 #!/app/.venv/bin/python
-"""Minimal pinentry stub for rbw.
+"""Pinentry stub for rbw.
 
-Implements just enough of the Assuan pinentry protocol to hand the master
-password (from the BW_PASSWORD env var) back to rbw during `rbw unlock`.
+rbw asks for three different credentials via pinentry during the
+register + unlock flow:
+
+  - "Client ID"       → BW_CLIENT_ID     (during `rbw register`)
+  - "Client Secret"   → BW_CLIENT_SECRET (during `rbw register`)
+  - "Master Password" → BW_PASSWORD      (during `rbw unlock`)
+
+We dispatch based on the SETPROMPT / SETDESC text rbw sends before
+each GETPIN. Both underscored (env-style) and no-underscore (bw-style)
+env var names are accepted for the API-key creds.
 """
 
 import os
 import sys
 
+CLIENT_ID = os.environ.get("BW_CLIENT_ID") or os.environ.get("BW_CLIENTID") or ""
+CLIENT_SECRET = (
+    os.environ.get("BW_CLIENT_SECRET") or os.environ.get("BW_CLIENTSECRET") or ""
+)
+PASSWORD = os.environ.get("BW_PASSWORD", "")
+
+
+def _pick(prompt: str, desc: str) -> str:
+    text = f"{prompt} {desc}".lower()
+    if "client id" in text or "clientid" in text or "client_id" in text:
+        return CLIENT_ID
+    if "client secret" in text or "clientsecret" in text or "client_secret" in text:
+        return CLIENT_SECRET
+    return PASSWORD
+
 
 def main() -> None:
-    password = os.environ.get("BW_PASSWORD", "")
-
     sys.stdout.write("OK Pleased to meet you\n")
     sys.stdout.flush()
+
+    prompt = ""
+    desc = ""
 
     for raw in sys.stdin:
         line = raw.strip()
         if not line:
             continue
-        cmd = line.split(" ", 1)[0].upper()
-        if cmd == "GETPIN":
-            sys.stdout.write(f"D {password}\nOK\n")
+        parts = line.split(" ", 1)
+        cmd = parts[0].upper()
+        arg = parts[1] if len(parts) > 1 else ""
+
+        if cmd == "SETPROMPT":
+            prompt = arg
+            sys.stdout.write("OK\n")
+        elif cmd == "SETDESC":
+            desc = arg
+            sys.stdout.write("OK\n")
+        elif cmd == "GETPIN":
+            value = _pick(prompt, desc)
+            # Log which credential was served (length only, never the value)
+            sys.stderr.write(
+                f"pinentry: prompt={prompt!r} desc={desc!r} returned_len={len(value)}\n"
+            )
+            sys.stderr.flush()
+            sys.stdout.write(f"D {value}\nOK\n")
+            prompt = ""
+            desc = ""
         elif cmd == "BYE":
             sys.stdout.write("OK closing connection\n")
             sys.stdout.flush()
             return
         else:
-            # SETPROMPT, SETDESC, SETTITLE, OPTION, etc. — acknowledge and move on.
             sys.stdout.write("OK\n")
         sys.stdout.flush()
 


### PR DESCRIPTION
## Root cause

Vaultwarden was returning 400 "Malformed client_id" on every `rbw register`. The actual reason — confirmed by VW server logs:

```
ERROR Malformed client_id. IP: 172.18.0.1.
```

rbw asks for `client_id` and `client_secret` **via pinentry**, not env vars, before sending the API-key OAuth request to `/identity/connect/token`. Our pinentry stub returned `BW_PASSWORD` for every `GETPIN`, so rbw POSTed the master password as the `client_id`. VW tried to parse it as `user.<uuid>`, found no dot, rejected as malformed.

## Fix

`pinentry.py` now:
- Tracks the `SETPROMPT` / `SETDESC` lines rbw sends before each `GETPIN`
- Returns the matching env var based on the prompt text:
  - `"Client ID"` → `BW_CLIENT_ID`
  - `"Client Secret"` → `BW_CLIENT_SECRET`
  - anything else (i.e. `"Master Password"`) → `BW_PASSWORD`
- Logs to stderr which credential was served (length only — never the value)

## Expected outcome

1. `rbw register` succeeds — receives `user.<uuid>` for client_id and the actual secret for client_secret
2. `rbw unlock` works as before — pinentry returns `BW_PASSWORD` since the prompt doesn't match the client-id/secret patterns
3. End-to-end backup completes

## Test plan
- [ ] Pull image, restart container
- [ ] Container logs show `pinentry: prompt='Client ID' ... returned_len=N` on first call
- [ ] `rbw register` exits 0
- [ ] Unlock + sync + export succeed
- [ ] Backup file appears in mounted volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)