### PR TITLE
fix(rbw): use `rbw login` for Vaultwarden, make API key optional

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,15 @@ services:
 
     environment:
       # Required credentials
-      BW_CLIENT_ID: "${BW_CLIENT_ID}"
-      BW_CLIENT_SECRET: "${BW_CLIENT_SECRET}"
       BW_PASSWORD: "${BW_PASSWORD}"
       BW_SERVER: "${BW_SERVER}"
       BW_EMAIL: "${BW_EMAIL}"
       BW_FILE_PASSWORD: "${BW_FILE_PASSWORD}"
+      # Optional — only needed if rbw ever asks for them via pinentry
+      # (e.g. Bitwarden Cloud bot-detection). Vaultwarden uses the
+      # master-password flow and ignores these.
+      BW_CLIENT_ID: "${BW_CLIENT_ID:-}"
+      BW_CLIENT_SECRET: "${BW_CLIENT_SECRET:-}"
 
       # Optional configuration
       # Only 'raw' is supported on the rbw backend (Argon2id + AES-256-GCM).

--- a/src/bw_client.py
+++ b/src/bw_client.py
@@ -202,15 +202,19 @@ class BitwardenClient:
     def login(
         self, email: str | None = None, password: str | None = None, raw: bool = True
     ) -> str | None:
-        """Register the device with the server using the personal API key.
+        """Log in to the vault server with email + master password.
 
-        rbw reads `email` and `base_url` from config.json (written in __init__)
-        and the API key from BW_CLIENTID / BW_CLIENTSECRET env vars. `register`
-        is idempotent — subsequent calls are no-ops once the device is enrolled.
+        rbw's `login` performs the prelogin → /identity/connect/token (password
+        grant) handshake. The master password is supplied via pinentry (which
+        reads BW_PASSWORD from env). `email` and `base_url` come from config.json.
+
+        Note: `rbw register` is for Bitwarden Cloud's bot-detection bypass via
+        personal API key — it does not apply to self-hosted Vaultwarden, and
+        `rbw login` is the correct entry point there.
         """
-        logger.info("Registering device with vault server via API key")
-        self._run(["register"], include_api_key=True)
-        logger.info("Device registered (or already registered)")
+        logger.info("Logging in to vault server")
+        self._run(["login"])
+        logger.info("Logged in successfully")
         return None
 
     @retry_with_backoff(max_attempts=3, base_delay=2.0)

--- a/src/run.py
+++ b/src/run.py
@@ -46,12 +46,16 @@ def validate_backup_dir(backup_dir: str) -> str:
 
 def main():
     # Vault access information
-    client_id = require_env("BW_CLIENT_ID")
-    client_secret = require_env("BW_CLIENT_SECRET")
     master_pw = require_env("BW_PASSWORD")
     server = require_env("BW_SERVER")
     email = require_env("BW_EMAIL")
     file_pw = require_env("BW_FILE_PASSWORD")
+    # API-key credentials are optional: rbw login uses the master-password
+    # flow against Vaultwarden. BW_CLIENT_ID / BW_CLIENT_SECRET are only
+    # needed if rbw ever asks for them via pinentry (e.g. Bitwarden Cloud's
+    # bot-detection path), and are harmless when set.
+    client_id = os.getenv("BW_CLIENT_ID")
+    client_secret = os.getenv("BW_CLIENT_SECRET")
 
     # Configuration
     backup_dir_raw = os.getenv("BACKUP_DIR", "/app/backups")


### PR DESCRIPTION
## Root cause

rbw 1.15.0's `register` command targets **Bitwarden Cloud's** bot-detection bypass via personal API key (`grant_type=client_credentials`). It is not the right entry point for **Vaultwarden**, which has no bot detection. Every `rbw register` call against VW returned 400 "Malformed client_id" because rbw was sending a built-in identifier (`cli`/`rbw`-like, no `user.<uuid>` prefix) as the `client_id`.

`rbw login` is the correct command for Vaultwarden — it does:
1. `POST /identity/accounts/prelogin` → KDF params for the account
2. `POST /identity/connect/token` (password grant) → access token
3. Done

Confirmed manually from inside the running container:
```
[vaultwarden] User TJ Greco logged in successfully. IP: 172.18.0.1
[vaultwarden] (login) POST /identity/connect/token => 200 OK
[vaultwarden] (sync) GET /api/sync => 200 OK
```

## Changes

- `BitwardenClient.login()` now calls `rbw login` instead of `rbw register`. The master password reaches rbw via our existing pinentry stub (which returns `BW_PASSWORD` for any non-client-id/secret prompt).
- `BW_CLIENT_ID` / `BW_CLIENT_SECRET` are no longer required in `run.py` — they become plain `os.getenv` (optional). They remain accepted (for future Bitwarden Cloud users) but are unused for the Vaultwarden master-password flow.
- `docker-compose.yml` marks the two API-key vars as optional with the `:-` default and documents what they're for.

## Note on "new device login" emails

The first `rbw login` from a freshly-started container will trigger one "new device login" email from VW (rbw generates a new device_id when none exists on disk). Subsequent logins within the same container instance reuse that device_id, so no repeated emails during normal operation. If you find the per-restart email noisy, a follow-up can persist `/app/.local/share/rbw` to a volume — out of scope here.

## Test plan
- [ ] Pull image, restart container
- [ ] Container logs show `INFO: Logging in to vault server` then `INFO: Logged in successfully`
- [ ] VW shows 200 OK for `/identity/connect/token` and `/api/sync`
- [ ] Backup file appears in mounted volume
- [ ] Subsequent backup cycles also succeed without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)