### PR TITLE
fix(lint): unblock Renovate PRs on ruff 0.16 default rule changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,20 @@ dev = [
 [tool.uv]
 package = false
 
+[tool.ruff.lint]
+# Rides ruff's default rule selection, which widened in 0.16. Note that the
+# defaults are not stable across ruff releases -- a future bump can introduce
+# new rules and turn every open Renovate PR red at once. If that churn becomes
+# a problem, replace this with an explicit `select`.
+ignore = [
+    # Broad `except Exception` is intentional here: these are the top-level
+    # error boundaries of a long-running backup daemon, plus best-effort
+    # logout cleanup in `finally`. Letting an unexpected exception escape
+    # would abort the backup or skip the vault logout.
+    "BLE001",
+    "S110",
+]
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 testpaths = ["tests"]

--- a/src/bw_client.py
+++ b/src/bw_client.py
@@ -1,15 +1,17 @@
-import os
-import subprocess
 import json
 import logging
+import os
 import re
+import subprocess
 import time
-from typing import Any, Callable
-from sys import stdout
-from pathlib import Path
+from collections.abc import Callable
 from functools import wraps
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from pathlib import Path
+from sys import stdout
+from typing import Any
+
 from argon2.low_level import Type, hash_secret_raw
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 # Constants for encryption
 SALT_SIZE = 16
@@ -36,8 +38,6 @@ logger = logging.getLogger(__name__)
 
 class BitwardenError(Exception):
     """Base exception for Bitwarden wrapper."""
-
-    pass
 
 
 def retry_with_backoff(
@@ -206,10 +206,9 @@ class BitwardenClient:
             if skip_next:
                 redacted.append("***REDACTED***")
                 skip_next = False
-            elif arg in sensitive_flags:
-                redacted.append(arg)
-                skip_next = True
-            elif arg in sensitive_commands and i + 1 < len(cmd):
+            elif arg in sensitive_flags or (
+                arg in sensitive_commands and i + 1 < len(cmd)
+            ):
                 redacted.append(arg)
                 skip_next = True
             else:

--- a/src/decrypt.py
+++ b/src/decrypt.py
@@ -1,11 +1,12 @@
 # decrypt.py
 import sys
 from getpass import getpass
+
+from argon2.low_level import Type, hash_secret_raw
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from cryptography.hazmat.primitives import hashes
-from cryptography.exceptions import InvalidTag
-from argon2.low_level import Type, hash_secret_raw
 
 SALT_SIZE = 16
 KEY_SIZE = 32

--- a/src/run.py
+++ b/src/run.py
@@ -1,10 +1,11 @@
+import logging
 import os
 import sys
-import logging
-from pathlib import Path
-from bw_client import BitwardenClient
 from datetime import datetime
+from pathlib import Path
 from sys import stdout
+
+from bw_client import BitwardenClient
 
 logging.basicConfig(
     level=logging.INFO,
@@ -98,8 +99,10 @@ def main():
             logger.error(f"Unlock failed: {e}")
             sys.exit(1)
 
-        # Generate timestamped filename
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        # Generate timestamped filename. `.astimezone()` attaches the local
+        # zone without shifting the clock, so filenames stay local-time as
+        # before -- it only makes the previously implicit tz explicit.
+        timestamp = datetime.now().astimezone().strftime("%Y%m%d_%H%M%S")
         backup_file = os.path.join(backup_dir, f"backup_{timestamp}.enc")
 
         logger.info(f"Starting export with mode: '{encryption_mode}'")


### PR DESCRIPTION
## Problem

The repo had **no ruff configuration** — no `[tool.ruff]` in `pyproject.toml`, no `ruff.toml`. So `uv run ruff check src/` enforced whatever ruff's built-in defaults happened to be at the installed version.

Ruff 0.16 widened those defaults, which turned Renovate PRs red on a routine version bump. #182 (lock file maintenance, `ruff 0.15.22 -> 0.16.0`) surfaced it. Verified against `main`:

| ruff | `check src/` |
|---|---|
| 0.15.22 | All checks passed |
| 0.16.0 | **17 errors** — `BLE001`×8, `S110`×2, `I001`×3, `UP035`, `PIE790`, `SIM114`, `DTZ005` |

This was never a lockfile problem — the lint gate was unpinned, so a dependency bump silently redefined "passing."

## Fix

Add `[tool.ruff.lint]` ignoring `BLE001` and `S110`. Both flag **deliberate** broad `except Exception` handling: the top-level error boundaries in `run.py` that log and `sys.exit(1)`, and best-effort `logout()` cleanup in `finally`. Letting those escape would abort the backup or skip vault logout.

Then apply the remaining fixes 0.16 asks for:

- sort imports in `bw_client.py`, `decrypt.py`, `run.py` (`I001`)
- import `Callable` from `collections.abc` (`UP035`)
- drop redundant `pass` in `BitwardenError` (`PIE790`)
- merge two identical branches in `_redact_command` (`SIM114`) — kept explicit parens around the `and` clause since this is the credential-redaction path
- make the backup filename timestamp tz-aware via `.astimezone()` (`DTZ005`)

## No behavior change

`.astimezone()` attaches the local zone **without shifting the clock**, so backup filenames are byte-identical to before — it only makes the previously implicit timezone explicit. Switching to UTC would have renamed everyone's backups; this doesn't.

## Verification

Lint, format, and the full 30-test suite pass under **both** ruff 0.15.22 (current lock) and 0.16.0 (#182's lock) — so this is safe to land ahead of the lockfile bump, and #182 goes green once rebased onto it.

## Note on durability

This rides ruff's *default* selection, which is not stable across releases — a future bump can add rules and cause this again. The comment in `pyproject.toml` flags the alternative (an explicit `select` list) if that churn becomes annoying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)